### PR TITLE
Handle login popup being closed

### DIFF
--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -90,13 +90,17 @@ export default function Login() {
         // Check if popup is still open
         try {
           if (loginWindow.closed) {
-             setIsConnecting(false);
-             setLoginStatus('idle');
-            toast({
-              title: "Login Verification Failed",
-              description: 'Login window was closed. Please complete the login process and try again.',
-              variant: "destructive",
-            });
+            // window closed unexpectedly; check login status one last time
+            const closedResult = await checkLoginStatus();
+            if (!closedResult.success) {
+              setIsConnecting(false);
+              setLoginStatus('idle');
+              toast({
+                title: "Login Verification Failed",
+                description: 'Login window was closed. Please complete the login process and try again.',
+                variant: "destructive",
+              });
+            }
             return;
           }
         } catch (e) {


### PR DESCRIPTION
## Summary
- handle closed login popup by checking login status before failing

## Testing
- `npm run check` *(fails: Property errors in various files)*

------
https://chatgpt.com/codex/tasks/task_b_683aef26988c83219cfd27da07b7d01f