### PR TITLE
Fix port binding for Render

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -65,10 +65,9 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = 5000;
+  // On platforms like Render the port is provided via the PORT
+  // environment variable. Default to 5000 for local development.
+  const port = process.env.PORT ? parseInt(process.env.PORT) : 5000;
   server.listen({
     port,
     host: "0.0.0.0",


### PR DESCRIPTION
## Summary
- use `process.env.PORT` when binding Express server

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683af4a74840832193aa735666a8ca1f